### PR TITLE
UG: addcontact

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -663,8 +663,8 @@ _Details coming soon ..._
 **Q**: How can I back up my data and restore it if something goes wrong?\
 **A**: Make a copy of `data/addressbook.json` and store it in a safe location such as a cloud or external drive. To restore, stop CPP, replace the `addressbook.json` in the app home `data/` folder, then start CPP.
 
-**Q**: How does CPP prevent duplicate contacts?\
-**A**: CPP performs basic duplicate detection at entry. **For contacts, classes and assignments**, the **name** should be unique. No 2 contacts should share the same name. If you attempt to add a contact that violates these rules, CPP will reject the entry and show an error message.
+**Q**: How does CPP prevent duplicate entries?\
+**A**: CPP performs basic duplicate detection at entry. **For contacts, classes and assignments**, the **name** should be unique. No 2 contacts, classes nor assignments should share the same name. If you attempt to add a contact, class or assignment that violates these rules, CPP will reject the entry and show an error message.
 
 **Q**: Can I export/import data for other systems (e.g., Excel)?\
 **A**: The primary data format used by CPP is JavaScript Object Notation (JSON). We do not support importing from Excel, but users may manually convert their Excel files to JSON format, adhering to the structure and format of the `addressbook.json` file generated on first run. Manual editing of `addressbook.json` is not recommended unless you are comfortable with JSON.


### PR DESCRIPTION
Closes #147 

This pull request updates the user guide documentation to clarify and expand on how to add contacts, including new optional fields and stricter validation rules. It also revises the duplicate detection explanation for contacts. The most important changes are:

**User command and format updates:**

* Changed the command for adding a contact from `add` to `addcontact`, and updated the format to include new optional fields: `c/CLASS_NAME` and `ass/ASSIGNMENT_NAME`. These allow allocating a contact to a class or assignment, with validation that the class or assignment exists.
* Expanded the format section to clearly list requirements and validation rules for each field (`NAME`, `PHONE_NUMBER`, `EMAIL`, `ADDRESS`), including uniqueness and allowed formats.

**Examples and usage:**

* Updated and expanded the example commands to demonstrate the new `addcontact` syntax and the use of class and assignment allocation.

**Duplicate detection clarification:**

* Revised the FAQ to clarify that only the contact `name` must be unique (not phone or email), updating the description of how duplicate contacts are prevented.