### PR TITLE
Fix delete contact not showing confirmation message for duplicate indices

### DIFF
--- a/src/main/java/cpp/commons/core/index/Index.java
+++ b/src/main/java/cpp/commons/core/index/Index.java
@@ -67,6 +67,11 @@ public class Index {
     }
 
     @Override
+    public int hashCode() {
+        return this.zeroBasedIndex;
+    }
+
+    @Override
     public String toString() {
         return new ToStringBuilder(this).add("zeroBasedIndex", this.zeroBasedIndex).toString();
     }

--- a/src/main/java/cpp/logic/commands/DeleteContactCommand.java
+++ b/src/main/java/cpp/logic/commands/DeleteContactCommand.java
@@ -1,8 +1,10 @@
 package cpp.logic.commands;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import cpp.commons.core.index.Index;
 import cpp.commons.util.ToStringBuilder;
@@ -32,8 +34,9 @@ public class DeleteContactCommand extends DeleteCommand {
 
         CommandUtil.checkContactIndices(lastShownList, this.targetIndices);
 
+        Set<Index> uniqueIndices = new LinkedHashSet<>(this.targetIndices);
         List<Contact> contactsToDelete = new ArrayList<>();
-        for (Index index : this.targetIndices) {
+        for (Index index : uniqueIndices) {
             contactsToDelete.add(lastShownList.get(index.getZeroBased()));
         }
 

--- a/src/test/java/cpp/logic/commands/DeleteContactCommandTest.java
+++ b/src/test/java/cpp/logic/commands/DeleteContactCommandTest.java
@@ -106,6 +106,24 @@ public class DeleteContactCommandTest {
     }
 
     @Test
+    public void execute_duplicateIndices_deletesOnceAndShowsMessage() {
+        Contact contactToDelete = this.model.getFilteredContactList()
+                .get(TypicalIndexes.INDEX_FIRST_CONTACT.getZeroBased());
+        DeleteContactCommand deleteCommand = new DeleteContactCommand(
+                List.of(TypicalIndexes.INDEX_FIRST_CONTACT,
+                        TypicalIndexes.INDEX_FIRST_CONTACT,
+                        TypicalIndexes.INDEX_FIRST_CONTACT));
+
+        String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete));
+
+        ModelManager expectedModel = new ModelManager(this.model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+
+        CommandTestUtil.assertCommandSuccess(deleteCommand, this.model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void equals() {
         DeleteContactCommand deleteFirstCommand = new DeleteContactCommand(
                 List.of(TypicalIndexes.INDEX_FIRST_CONTACT));


### PR DESCRIPTION
Fixes #260

The delete contact command failed to display the success message when duplicate indices were provided (e.g. `delete ct/1 1 1`). The contact was deleted but no confirmation was shown.

Changes:
- Added `hashCode` to `Index` to fulfil the `equals`/`hashCode` contract
- Added deduplication of indices in `DeleteContactCommand` as a fallback
- Added test covering duplicate indices input